### PR TITLE
Add noindex nofollow tag to the head

### DIFF
--- a/env.rb
+++ b/env.rb
@@ -5,7 +5,11 @@ require 'json/pure'
 get '/' do
   puts "Current env keys: #{ENV.keys.sort.inspect}"
   res = "<html><body style=\"margin:0px auto; width:80%; font-family:monospace\">"
-  res << "<head><title>Cloud Foundry Environment</title><meta name=\"viewport\" content=\"width=device-width\"></head>"
+  res << "<head>"
+  res << "<meta name=\"robots\" content=\"noindex, nofollow\">"
+  res << "<meta name=\"viewport\" content=\"width=device-width\">"
+  res << "<title>Cloud Foundry Environment</title>"
+  res << "</head>"
   res << "<h2>Cloud Foundry Environment</h2>"
   res << "<div><table>"
   ENV.keys.sort.each do |key|


### PR DESCRIPTION
Even though you'd probably not want to deploy this app in production and the `robots` meta tag _can_ be ignored by crawlers, it might still be a good idea to tell crawlers not to index this app or follow any links they might encounter here..
