### PR TITLE
Default to using random routes when pushing cf-env, for easier re-use…

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -2,3 +2,4 @@ applications:
 - name: cf-env
   memory: 256M
   buildpack: ruby_buildpack
+  random_route: true


### PR DESCRIPTION
… across cf deployments