### PR TITLE
Updated the app wrt cf-for-k8s

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,6 @@
 source 'https://rubygems.org'
 
-# DO NOT PIN THE RUBY VERSION
-# it will cause this app to break on newer CF buildpacks
-# which makes it less useful from a demo/test perspective.
-#ruby '2.4.0'
+ruby '2.7.0'
 
 gem 'sinatra'
 gem 'json_pure'

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '2.7.0'
+ruby '~> 2.7'
 
 gem 'sinatra'
 gem 'json_pure'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,4 +23,4 @@ DEPENDENCIES
   sinatra
 
 BUNDLED WITH
-   1.17.2
+   2.1.4

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: rackup -p $PORT
+web: bundle exec rackup -p $PORT

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,5 +1,3 @@
 applications:
 - name: cf-env
   memory: 256M
-  buildpacks:
-  - ruby_buildpack


### PR DESCRIPTION
When deploying this app on `cf-for-k8s`, the app errored out at a lot of stages. They are detailed as below:

1. Although the `Gemfile` doesn't pin the ruby version, the underlying CF somehow detects ruby 2.4.0 and errors out. To curb that, I bumped up ruby to use 2.7.0 and above (failed till version 2.6.0)
```
source 'https://rubygems.org'
   <unknown> -> "2.4.0"
GEM
   <unknown> -> "*"

   failed to satisfy "ruby" dependency version constraint "2.4.0": no compatible versions

   ERROR: failed to build: exit status 1
```
2. The bundler version had to be bumped to 2.1.4 from 1.17.2
```
Paketo Bundler Buildpack 0.0.152
   Resolving Bundler version
   Candidate version sources (in priority order):
   Gemfile.lock -> "1.17.2"
   <unknown>    -> "*"
   <unknown>    -> "*"


   failed to satisfy "bundler" dependency version constraint "1.17.2": no compatible versions
   ERROR: failed to build: exit status 1
```
3. The Procfile had to be changed because of the following error:
```
"Error", "exit_status"=>127, "exit_description"=>"Error", "crash_count"=>0, "crash_timestamp"=>1603863892, "version"=>"cf0ec3cd-38fa-40d0-8a64-6d20b2c07fa7"}
   2020-10-28T01:44:52.00-0400 [API/0] OUT Process has crashed with type: "web"
   2020-10-28T01:44:52.35-0400 [APP/PROC/WEB/0f9620f8-6247-4bfb-9e63-c4e88d493528] OUT rackup: rackup: command not found
```
4. The `manifest.yml` uses a non-CNB ruby buildpack. I removed that. CF for k8s detects the ruby paketo buildpack for this app.